### PR TITLE
Fix: Fetch valid download url

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,8 @@ else
   CRYSTAL_VERSION_REASON='due to latest release at https://github.com/crystal-lang/crystal'
 fi
 
-CRYSTAL_URL=`${CURL} https://github.com/crystal-lang/crystal/releases/tag/${CRYSTAL_VERSION} | grep 'https://github.com/crystal-lang/crystal/releases/download/.*-linux-x86_64.tar.gz' | sed 's/.*: "\(.*\)"/\1/'`
+TAG_NAME=`${CURL} https://api.github.com/repos/crystal-lang/crystal/releases | json_value tag_name | grep ${CRYSTAL_VERSION}`
+CRYSTAL_URL=`${CURL} https://api.github.com/repos/crystal-lang/crystal/releases/tags/${TAG_NAME} | grep 'https://github.com/crystal-lang/crystal/releases/download/.*-linux-x86_64.tar.gz' | sed 's/.*: "\(.*\)"/\1/'`
 CRYSTAL_DIR=$BUILD_DIR/.heroku/crystal
 unset GIT_DIR
 


### PR DESCRIPTION
Hi there,

Previous PR fix ([#1](https://github.com/luckyframework/heroku-buildpack-crystal/pull/1)) only works for `0.24.1` version and breaks everything else. Reason for that is that [crystal-lang/crystal](https://github.com/crystal-lang/crystal/) has inconsistent tagging. `0.24.1` was tagged with `v0.24.1`, any other version skips `v` prefix for tag name.

Tag names can be verified here: [https://api.github.com/repos/crystal-lang/crystal/releases](https://api.github.com/repos/crystal-lang/crystal/releases)

This PR addresses both issues and first fetch valid tag name for given version so for `0.24.2` will return `0.24.2` and for `0.24.1` -> `v0.24.1`.

Just tested on `0.24.2`:

![screenshot_20180422_002838](https://user-images.githubusercontent.com/235847/39089376-0a1384a4-45c6-11e8-9ab2-ce87b7dcc5c2.png)

Hopefully this resolves all issues.
