### PR TITLE
Switch to shards install instead of crystal deps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ echo "export PATH=\$HOME/.heroku/crystal/bin:\$PATH" >> "$BUILD_DIR/.profile.d/c
 cd $BUILD_DIR
 
 start "Installing Dependencies"
-  crystal deps --production
+  shards install --production
 finished
 
 NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`


### PR DESCRIPTION
I believe Crystal 0.25 has deprecated `crystal deps` as I am getting an ```Please use 'shards': 'crystal deps' has been removed``` error when pushing to Heroku.

https://github.com/crystal-lang/crystal/pull/5544