### PR TITLE
update compile to use shards build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,20 +73,9 @@ echo "export PATH=\$HOME/.heroku/crystal/bin:\$PATH" >> "$BUILD_DIR/.profile.d/c
 # Build the project
 cd $BUILD_DIR
 
-start "Installing Dependencies"
-shards install --production
+start "Installing shards and compiling project"
+shards build --production --release
 finished
-
-if [ -f app.cr ]; then
-    start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"
-    crystal build app.cr --release $NO_DEBUG_IF_AVAILABLE
-    finished
-else
-    eval $(parse_yaml shard.yml "shard_")
-    start "Compiling src/${shard_name}.cr (auto-detected from shard.yml)"
-    crystal build src/${shard_name}.cr --release -o app
-    finished
-fi
 
 start "Setting up Lucky tasks"
 


### PR DESCRIPTION
Shards now has a `shards build` command which will build all binary outputs of the project. Rather than parsing over the shard.yml and manually selecting a build target, this simply builds with shards.

Thoughts?